### PR TITLE
支持以鍵盤瀏覽方案?

### DIFF
--- a/CodeX/CodeX.cpp
+++ b/CodeX/CodeX.cpp
@@ -226,9 +226,9 @@ void CodeX::connect()
 		&ChipSolver::setUseAlt
 	);
 	QObject::connect(
-		this->ui->solutionTable,
-		&QTableView::clicked,
-		[&](QModelIndex index)
+		this->ui->solutionTable->selectionModel(),
+		&QItemSelectionModel::currentRowChanged,
+		[&](const QModelIndex index)
 		{
 			this->selectSolution(index.row());
 		});


### PR DESCRIPTION
你好
想請問能否增加用鍵盤上下鍵來查看方案的功能，目前clicked信號似乎只能用以左鍵單擊來選擇方案查看。