### PR TITLE
在Windows下使用特定中文標準數字格式會產生數字顯示問題

### DIFF
--- a/CodeX/main.cpp
+++ b/CodeX/main.cpp
@@ -11,6 +11,12 @@ int main(int argc, char *argv[])
 	QApplication::setOrganizationName("xuanxuan.tech");
 	QApplication::setApplicationName("CodeX");
 	QSettings::setDefaultFormat(QSettings::IniFormat);
+	const QLocale locale = QLocale::system();
+	// workaround QTBUG-85409 by overwriting default locale
+	if (QStringLiteral(u"\u3008") == locale.toString(1)) {
+		QLocale::setDefault(QLocale::system().name());
+	}
+
 	CodeX::instance()->show();
 	return a.exec();
 }


### PR DESCRIPTION
當Windows 系統數字設定成圖一時，[QTBUG-85409](https://bugreports.qt.io/browse/QTBUG-85409)會造成QWidget產生如圖二一堆奇奇怪怪的數字。複寫系統預設QLocale可以解決這個問題，不過不知道會不會影響其他QLocale相關的格式。



![image](https://github.com/xxzl0130/CodeX/assets/46232230/a7bac999-6622-4747-8cf6-88c00f978f74)
圖一: Standard digits設定更改為"〇一二三四五六七八九"

![image](https://github.com/xxzl0130/CodeX/assets/46232230/1746bad0-ade5-4d02-a743-3029a1f3dc70)
圖二: QT5 bug導致數字被更改成亂七八糟的格式

![image](https://github.com/xxzl0130/CodeX/assets/46232230/bad83d2f-5eea-41fb-88e4-5f37fed20775)
圖三: 更改預設的QLocale 後